### PR TITLE
Use estimated hours for DM sessions

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -259,13 +259,14 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   
   // Assignments CRUD
   const addAssignment = (assignment: Omit<Assignment, 'id' | 'relatedEvents'>) => {
-    const newAssignment = { 
-      ...assignment, 
-      id: uuidv4(), 
-      relatedEvents: [] 
+    const newAssignment = {
+      ...assignment,
+      id: uuidv4(),
+      relatedEvents: []
     };
-    setAssignments([...assignments, newAssignment]);
-    
+
+    let assignmentToStore = newAssignment;
+
     // Auto generate study sessions if it's a DM
     if (assignment.type === 'dm') {
       const generatedSessions = generateStudySessions(
@@ -278,28 +279,27 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         subjects.find(s => s.id === assignment.subjectId)!,
         events,
         studySessions,
-        userPreferences
+        userPreferences,
+        assignment.estimatedHours
       );
-      
+
       if (generatedSessions.length > 0) {
         setStudySessions([...studySessions, ...generatedSessions]);
-        
-        // Update the assignment with related study sessions
-        const updatedAssignment = {
+
+        assignmentToStore = {
           ...newAssignment,
           relatedEvents: generatedSessions.map(s => s.id)
         };
-        setAssignments([...assignments, updatedAssignment]);
-        
+
         addNotification({
           title: 'Étude planifiée',
           message: `${generatedSessions.length} sessions d'étude ont été ajoutées pour ${assignment.title}`,
           type: 'success',
         });
-      } else {
-        setAssignments([...assignments, newAssignment]);
       }
     }
+
+    setAssignments([...assignments, assignmentToStore]);
   };
   
   const updateAssignment = (assignment: Assignment) => {
@@ -384,7 +384,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
           subjects.find(s => s.id === assignment.subjectId)!,
           events,
           newSessions,
-          userPreferences
+          userPreferences,
+          assignment.estimatedHours
         );
         
         if (generatedSessions.length > 0) {

--- a/src/utils/studyPlanner.ts
+++ b/src/utils/studyPlanner.ts
@@ -104,7 +104,8 @@ export const generateStudySessions = (
   subject: Subject,
   events: Event[],
   existingStudySessions: StudySession[],
-  preferences: UserPreferences
+  preferences: UserPreferences,
+  estimatedHours?: number
 ): StudySession[] => {
   const result: StudySession[] = [];
   const eventDate = parseISO(event.startTime);
@@ -165,16 +166,17 @@ export const generateStudySessions = (
   } 
   // For DMs, generate sessions based on estimated work time
   else if (event.type === 'dm') {
-    // Try to find the assignment related to this DM
-    const assignment = existingStudySessions.find(s => s.relatedToId === event.id);
-    const estimatedHours = assignment ? 2 : 1;
-    
-    // Calculate days between now and deadline
-    const daysUntilDeadline = differenceInDays(eventDate, now);
-    let numberOfSessions = Math.min(daysUntilDeadline, estimatedHours);
-    
-    // Ensure at least one session if the deadline is tomorrow
-    numberOfSessions = Math.max(numberOfSessions, 1);
+    const hoursToSpend = estimatedHours ?? 2;
+
+    // Calculate how many study sessions are needed based on preferred session duration
+    const sessionDurationHours = studyDuration / 60;
+    let numberOfSessions = Math.ceil(hoursToSpend / sessionDurationHours);
+
+    // Days available until the deadline
+    const daysUntilDeadline = Math.max(differenceInDays(eventDate, now), 1);
+
+    // Avoid generating more sessions than days available
+    numberOfSessions = Math.min(numberOfSessions, daysUntilDeadline);
     
     // Generate sessions distributed over days
     for (let i = 0; i < numberOfSessions; i++) {


### PR DESCRIPTION
## Summary
- improve study session generation for DM by considering estimated hours
- avoid duplicated assignment entries when study sessions auto-generated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684212e90924832281e0bd9e7c4d6ca1